### PR TITLE
[IMP] openacademy: Set form fields to readonly based on workflow states

### DIFF
--- a/openacademy/view/openacademy_session_view.xml
+++ b/openacademy/view/openacademy_session_view.xml
@@ -22,14 +22,16 @@
 				string="Mark as done"
 				states="confirmed"
 				class="oe_highlight"/>
-			<field name="state" widget="statusbar"/>	
+			<field name="state" widget="statusbar"/>
 		    </header>
 		    <sheet>
                         <group string="General">
                             <field name="course_id"/>
-                            <field name="name"/>
+                            <field name="name"
+                                attrs="{'readonly':[('state','!=','draft')],}"
+                            />
                             <field name="taken_seats" widget="progressbar"/>
-			    <field name="instructor_id"/>                            
+			    <field name="instructor_id"/>
                             <field name="active"/>
                         </group>
                         <group string="Schedule">


### PR DESCRIPTION
### [VX#5845](https://www.vauxoo.com/web#id=5845&view_type=form&model=project.task&action=138)

There are two options to do this:
- Modifiying the view.
  - Adding the attrs readonly into the field that you want.
  - However, this only applies into the modified view.
- Modifiying the fields in the model.
  - Adding a method that returns a dictionary with the attribute values for key-state, e.g., no_editable_states.
  - Then, add the attribute states=no_editable_states into the fields of your model.
    This is a better approach if you don't want to change the views one by one
    because your are modifying the model's fields.
